### PR TITLE
Allow to customize log path

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -640,7 +640,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function getMonologHandler()
     {
-        return (new StreamHandler(storage_path('logs/lumen.log'), Logger::DEBUG))
+        $logPath = getenv('APP_LOG_PATH') ?: storage_path('logs/lumen.log');
+        
+        return (new StreamHandler($logPath, Logger::DEBUG))
                             ->setFormatter(new LineFormatter(null, null, true, true));
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -640,7 +640,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function getMonologHandler()
     {
-        $logPath = getenv('APP_LOG_PATH') ?: storage_path('logs/lumen.log');
+        $logPath = env('APP_LOG_PATH', storage_path('logs/lumen.log'));
         
         return (new StreamHandler($logPath, Logger::DEBUG))
                             ->setFormatter(new LineFormatter(null, null, true, true));


### PR DESCRIPTION
Allow to write logs anywhere. 
Add a new `APP_LOG_PATH` default to storage_path('logs/lumen.log')